### PR TITLE
Default methods

### DIFF
--- a/src/default_methods.rs
+++ b/src/default_methods.rs
@@ -1,0 +1,26 @@
+use syn::{Block, ImplItem, ImplItemMethod, TraitItemMethod};
+use syn::parse::{Parse, ParseStream, Result as ParseResult};
+use syn::token::Brace;
+
+pub(crate) struct DefaultBody(pub(crate) Vec<ImplItem>);
+
+impl Parse for DefaultBody {
+    fn parse(input: ParseStream) -> ParseResult<Self> {
+        let mut items = Vec::new();
+        while !input.is_empty() {
+            let item = input.parse::<TraitItemMethod>()?;
+            items.push(ImplItem::Method(ImplItemMethod {
+                attrs: item.attrs,
+                vis: syn::Visibility::Inherited,
+                defaultness: None,
+                sig: item.sig,
+                block: Block {
+                    brace_token: Brace::default(),
+                    stmts: Vec::new(),
+                },
+            }));
+        }
+        Ok(DefaultBody(items))
+    }
+}
+

--- a/src/default_methods.rs
+++ b/src/default_methods.rs
@@ -1,5 +1,5 @@
 use syn::{Block, ImplItem, ImplItemMethod, TraitItemMethod};
-use syn::parse::{Parse, ParseStream, Result as ParseResult};
+use syn::parse::{Error, Parse, ParseStream, Result as ParseResult};
 use syn::token::Brace;
 
 pub(crate) struct DefaultBody(pub(crate) Vec<ImplItem>);
@@ -7,20 +7,32 @@ pub(crate) struct DefaultBody(pub(crate) Vec<ImplItem>);
 impl Parse for DefaultBody {
     fn parse(input: ParseStream) -> ParseResult<Self> {
         let mut items = Vec::new();
+        let mut error = None;
         while !input.is_empty() {
             let item = input.parse::<TraitItemMethod>()?;
-            items.push(ImplItem::Method(ImplItemMethod {
-                attrs: item.attrs,
-                vis: syn::Visibility::Inherited,
-                defaultness: None,
-                sig: item.sig,
-                block: Block {
-                    brace_token: Brace::default(),
-                    stmts: Vec::new(),
-                },
-            }));
+            if let Some(body) = item.default {
+                let new_err = Error::new_spanned(body, "Default method can't have a body");
+                match &mut error {
+                    None => error = Some(new_err),
+                    Some(e) => e.combine(new_err),
+                }
+            } else {
+                items.push(ImplItem::Method(ImplItemMethod {
+                    attrs: item.attrs,
+                    vis: syn::Visibility::Inherited,
+                    defaultness: None,
+                    sig: item.sig,
+                    block: Block {
+                        brace_token: Brace::default(),
+                        stmts: Vec::new(),
+                    },
+                }));
+            }
         }
-        Ok(DefaultBody(items))
+        match error {
+            None => Ok(DefaultBody(items)),
+            Some(err) => Err(err),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
 
 extern crate proc_macro;
 
+mod default_methods;
 mod expand;
 mod parse;
 mod visibility;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,6 +3,8 @@ mod types {
 
     trait Trait {
         fn f<T: ?Sized>(self);
+        // A default method
+        fn g(&self) {}
     }
 
     pub struct Struct;
@@ -10,11 +12,16 @@ mod types {
     #[inherent(pub)]
     impl Trait for Struct {
         fn f<T: ?Sized>(self) {}
+        default! {
+            fn g(&self);
+        }
     }
 }
 
 #[test]
 fn test() {
     // types::Trait is not in scope.
-    types::Struct.f::<str>();
+    let s = types::Struct;
+    s.g();
+    s.f::<str>();
 }

--- a/tests/ui/default-with-body.rs
+++ b/tests/ui/default-with-body.rs
@@ -1,0 +1,18 @@
+use inherent::inherent;
+
+trait A {
+    fn a(&self) {}
+}
+
+struct X;
+
+#[inherent]
+impl A for X {
+    default! {
+        fn a(&self) {
+            println!("Default with a body >:-P");
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/default-with-body.stderr
+++ b/tests/ui/default-with-body.stderr
@@ -1,0 +1,8 @@
+error: Default method can't have a body
+  --> $DIR/default-with-body.rs:12:21
+   |
+12 |           fn a(&self) {
+   |  _____________________^
+13 | |             println!("Default with a body >:-P");
+14 | |         }
+   | |_________^

--- a/tests/ui/nonsense-in-default.rs
+++ b/tests/ui/nonsense-in-default.rs
@@ -1,0 +1,16 @@
+use inherent::inherent;
+
+trait A {
+    fn a(&self) {}
+}
+
+struct X;
+
+#[inherent]
+impl A for X {
+    default! {
+        const NONSENSE: usize = 1;
+    }
+}
+
+fn main() {}

--- a/tests/ui/nonsense-in-default.stderr
+++ b/tests/ui/nonsense-in-default.stderr
@@ -1,0 +1,5 @@
+error: expected `fn`
+  --> $DIR/nonsense-in-default.rs:12:15
+   |
+12 |         const NONSENSE: usize = 1;
+   |               ^^^^^^^^


### PR DESCRIPTION
This implements #1.

However, I'm not entirely happy with it. It gets the job done, but I suspect several problems will happen:
* It'll probably accept more than it should (eg. having `default! { fn stuff(&self) { println("Hello world"); } }`).
* If the inside of `default` is not syntactically correct, it'll panic instead of providing nice error message with all the arrows pointing at it, etc.
* I'm not sure if my approach of faking impl methods and feeding them to the rest of the code is really elegant.

Therefore, I'd appreciate some high level hint into what direction to improve it, how to do the error handling better. Or a link / recommendation to some other crate I could get inspired with.

Thank you