### PR TITLE
Add backticks to default doc string

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -47,7 +47,7 @@ pub fn inherent(vis: Visibility, mut input: TraitImpl) -> TokenStream {
         let default_doc = if has_doc {
             None
         } else {
-            let msg = format!("See [{}::{}]", quote!(#trait_), ident);
+            let msg = format!("See [`{}::{}`]", quote!(#trait_), ident);
             Some(quote!(#[doc = #msg]))
         };
 


### PR DESCRIPTION
Otherwise it isn't correctly rendered as an intra-doc link.