### PR TITLE
Remove spaces from trait path

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -47,7 +47,8 @@ pub fn inherent(vis: Visibility, mut input: TraitImpl) -> TokenStream {
         let default_doc = if has_doc {
             None
         } else {
-            let msg = format!("See [`{}::{}`]", quote!(#trait_), ident);
+            let trai = quote!(#trait_).to_string().replace(" ", "");
+            let msg = format!("See [`{}::{}`]", trai, ident);
             Some(quote!(#[doc = #msg]))
         };
 


### PR DESCRIPTION
`quote!` renders paths to the traits as `name :: module :: trait`,
breaking auto-linking in docs.
We can safely remove spaces here.

---

I'm sorry, the previous fix from #6 didn't actually solve the problem. This one does.