### PR TITLE
Omit generic parameters from rustdoc link

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -47,8 +47,12 @@ pub fn inherent(vis: Visibility, mut input: TraitImpl) -> TokenStream {
         let default_doc = if has_doc {
             None
         } else {
-            let trai = quote!(#trait_).to_string().replace(" ", "");
-            let msg = format!("See [`{}::{}`]", trai, ident);
+            let mut link = String::new();
+            for segment in &trait_.segments {
+                link += &segment.ident.to_string();
+                link += "::";
+            }
+            let msg = format!("See [`{}{}`]", link, ident);
             Some(quote!(#[doc = #msg]))
         };
 


### PR DESCRIPTION
The `replace(" ", "")` logic from #7 would tend to break things when dealing with e.g. `path::to::Trait<dyn Thing>`.

IIUC the generics don't need to be in the doc link because just the trait name uniquely identifies the rendered documentation page.

@badboy