### PR TITLE
Add ui test of inherent impl on blanket impl

### DIFF
--- a/tests/ui/blanket-impl.rs
+++ b/tests/ui/blanket-impl.rs
@@ -1,0 +1,12 @@
+use inherent::inherent;
+
+trait A {
+    fn a(&self);
+}
+
+#[inherent]
+impl<T> A for T {
+    fn a(&self) {}
+}
+
+fn main() {}

--- a/tests/ui/blanket-impl.stderr
+++ b/tests/ui/blanket-impl.stderr
@@ -1,0 +1,7 @@
+error[E0118]: no nominal type found for inherent implementation
+ --> $DIR/blanket-impl.rs:8:15
+  |
+8 | impl<T> A for T {
+  |               ^ impl requires a nominal type
+  |
+  = note: either implement a trait on it or create a newtype to wrap it instead


### PR DESCRIPTION
This expands to something like `impl<T> T { ... }` which is invalid.