### PR TITLE
Remove rustfmt skip on pub fn in impl

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -12,7 +12,6 @@ mod types {
     #[inherent]
     impl Trait for Struct {
         pub fn f<T: ?Sized>(self) {}
-        #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/4960
         pub fn g(&self);
     }
 }


### PR DESCRIPTION
The rustfmt bug was fixed by https://github.com/rust-lang/rustfmt/pull/4961.