### PR TITLE
Support async function in trait

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -113,7 +113,8 @@ fn fwd_method(
         .unzip();
 
     let types = generics.type_params().map(|param| &param.ident);
-    let body = quote!(<Self as #trait_>::#ident::<#(#types,)*>(#(#arg_val,)*));
+    let wait = asyncness.map(|_| quote!( .await ));
+    let body = quote!(<Self as #trait_>::#ident::<#(#types,)*>(#(#arg_val,)*)#wait);
     let block = quote_spanned!(body_span=> { #body });
     let args = quote_spanned!(sig.paren_token.span=> (#(#arg_pat)*));
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,6 +5,9 @@ mod types {
         fn f<T: ?Sized>(self);
         // A default method
         fn g(&self) {}
+
+        #[rustversion::since(1.75)]
+        async fn a(&self);
     }
 
     pub struct Struct;
@@ -13,6 +16,9 @@ mod types {
     impl Trait for Struct {
         pub fn f<T: ?Sized>(self) {}
         pub fn g(&self);
+
+        #[rustversion::since(1.75)]
+        pub async fn a(&self) {}
     }
 }
 
@@ -22,4 +28,13 @@ fn test() {
     let s = types::Struct;
     s.g();
     s.f::<str>();
+}
+
+#[rustversion::since(1.75)]
+#[test]
+fn test_async() {
+    fn assert_future<T: std::future::Future<Output = ()>>(_: T) {}
+
+    let s = types::Struct;
+    assert_future(s.a());
 }


### PR DESCRIPTION
Support async function in trait by adding `.await` after trait method call.

Fixes #21